### PR TITLE
Upgrade genui-sdk ver to 0.6.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@crayonai/react-ui": "^0.7.10",
         "@crayonai/stream": "^0.6.4",
-        "@thesysai/genui-sdk": "^0.6.13",
+        "@thesysai/genui-sdk": "^0.6.18",
         "next": "15.2.4",
         "openai": "^4.91.1",
         "react": "^19.0.0",
@@ -70,9 +70,9 @@
       }
     },
     "node_modules/@crayonai/react-ui": {
-      "version": "0.7.10",
-      "resolved": "https://registry.npmjs.org/@crayonai/react-ui/-/react-ui-0.7.10.tgz",
-      "integrity": "sha512-rDox9h2RUgSupX9ZHb4OMkQxmI5YGmcU6CWcW4BpBxA9tC6BPccud18xHGBg3gfIMwbfZbwIilGNQ8lmmIdBxA==",
+      "version": "0.7.14",
+      "resolved": "https://registry.npmjs.org/@crayonai/react-ui/-/react-ui-0.7.14.tgz",
+      "integrity": "sha512-gaB49F/f83j5bvc7Xz9l1ZPkLjWOMknrOGEJnxRUE42Emv7pe9tdHhpqOmi2Y2j6YgZoxR6AIMA2R02vU4QTLA==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom": "^2.1.2",
@@ -2985,9 +2985,9 @@
       }
     },
     "node_modules/@thesysai/genui-sdk": {
-      "version": "0.6.13",
-      "resolved": "https://registry.npmjs.org/@thesysai/genui-sdk/-/genui-sdk-0.6.13.tgz",
-      "integrity": "sha512-kBOwWuKVi6doeJ9+BhbFJTWwD+GlRvhLpeCiopSsdga3TMhx7a6s5n03mi1pZHYf0F7mUstCESI8qDh+2HC1GA==",
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/@thesysai/genui-sdk/-/genui-sdk-0.6.18.tgz",
+      "integrity": "sha512-UefEBzZd1G1VcJ3/PS4rlQSjiiw/1iik06hcneceULK8appME8pxpvm/1qud18GVhUGd3DyVkfFF7X7C6+mbEg==",
       "license": "see LICENSE.md",
       "dependencies": {
         "clsx": "^2.1.0",
@@ -2996,7 +2996,6 @@
         "react-error-boundary": "^5.0.0",
         "rehype-katex": "^7.0.1",
         "remark-breaks": "^4.0.0",
-        "remark-emoji": "^5.0.1",
         "remark-gfm": "^4.0.0",
         "remark-math": "^6.0.0",
         "tiny-invariant": "1.3.3",
@@ -3004,7 +3003,7 @@
       },
       "peerDependencies": {
         "@crayonai/react-core": "^0.7.3",
-        "@crayonai/react-ui": "^0.7.6",
+        "@crayonai/react-ui": "^0.7.13",
         "lucide-react": "^0.469.0",
         "react": ">=18.3.1",
         "react-dom": ">=18.3.1"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@crayonai/react-ui": "^0.7.10",
     "@crayonai/stream": "^0.6.4",
-    "@thesysai/genui-sdk": "^0.6.13",
+    "@thesysai/genui-sdk": "^0.6.18",
     "next": "15.2.4",
     "openai": "^4.91.1",
     "react": "^19.0.0",


### PR DESCRIPTION
# Changelog

- Upgrade `@thesysai/genui-sdk` version to the latest `^0.6.18`
  - Necessary for all the latest features such as `makeC1Response` required for thinking states.